### PR TITLE
Orthographische und grammatikalische Korrekturen

### DIFF
--- a/2119de.rst
+++ b/2119de.rst
@@ -6,62 +6,64 @@ Status dieses Memorandum
 
 Basierend auf RFC 2119 definiert dieses Dokument Schlüsselwörter zum
 Kennzeichen von Anforderungen. Dies ist keine Übersetzung, sondern eine
-Interpretation für Deutschsprachige, damit dieses grossartige Werkzeug auch für
+Interpretation für Deutschsprachige, damit dieses großartige Werkzeug auch für
 deutsche Dokumentationen eingesetzt werden kann.
 
 Zusammenfassung
 ---------------
 
 Im Standardisierungsverfahren werden in vielen Dokumenten Schlüsselwörter
-verwendet um Anforderungen der Spezifikation aufzuzeigen. Diese Wörter werden
-oft gross geschrieben. Autoren die diesen Richtlinien folgen, sollten den
+verwendet, um Anforderungen der Spezifikation aufzuzeigen. Diese Wörter werden
+oft groß geschrieben. Autoren, die diesen Richtlinien folgen, sollten den
 folgenden Satz am Anfang ihres Dokuments einfügen::
 
-   Die Schlüsselwörter "MUSS", "DARF NICHT", "ERFORDERLICH", "SOLL", "VERBOTEN",
-   "NÖTIG", "NICHT NÖTIG", "SOLL NICHT", "EMPFOHLEN", "DARF", "KANN" und
-   "OPTIONAL" werden nach 2119de interpretiert. https://goo.gl/6QZH4J
+   Die Schlüsselwörter "MUSS", "DARF NICHT", "ERFORDERLICH", "SOLL", 
+   "VERBOTEN", "NÖTIG", "NICHT NÖTIG", "SOLL NICHT", "EMPFOHLEN", "DARF", 
+   "KANN" und "OPTIONAL" werden nach 2119de interpretiert. 
+   https://goo.gl/6QZH4J
 
-Beachten Sie dass die Aussagekraft dieser Wörter, durch die Anforderungen des Dokuments
-in welchem sie verwendet werden, relativiert werden können.
+Beachten Sie, dass die Aussagekraft dieser Worte, durch die Anforderungen des 
+Dokuments, in welchem sie verwendet werden, relativiert werden können.
 
 Definition
 ----------
 
 MUSS
-   oder die Schlüsselwörter "ERFORDERLICH" oder "NÖTIG" bedeuten,
-   dass die Definition eine absolute Anforderung der Spezifikation ist.
+   sowie die Schlüsselwörter "ERFORDERLICH" und "NÖTIG" bedeuten, dass die 
+   Definition eine absolute Anforderung der Spezifikation ist.
 
 DARF NICHT
-   oder das Wort "VERBOTEN" Bedeutet, dass die Definition ein
+   und das Wort "VERBOTEN" bedeuten, dass die Definition ein
    absolutes Verbot der Spezifikation ist.
 
 SOLL
-   oder das Adjektiv "EMPFOHLEN" bedeutet, dass es in speziellen Situationen
-   Gründe geben kann, diese Spezifikation zu ignorieren. Natürlich müssen die
-   Auswirkungen voll und ganz verstanden und sorgfältig abgewägt werden, bevor
-   von der Spezifikation abgewichen wird.
+   und das Adjektiv "EMPFOHLEN" respektive das Verb "EMPFEHLEN" bedeuten, dass 
+   es in speziellen Situationen Gründe geben kann, diese Spezifikation zu 
+   ignorieren. Natürlich müssen die Auswirkungen voll und ganz verstanden und 
+   sorgfältig abgewägt werden bevor von der Spezifikation abgewichen wird.
 
 SOLL NICHT
-   oder "NICHT EMPFOHLEN" bedeutet, dass es gute Gründe in speziellen Situationen
-   geben kann, dass dieses Verhalten akzeptabel, ja sogar nützlich sein kann.
-   Natürlich müssen die Auswirkungen voll und ganz verstanden und sorgfältig
-   abgewägt werden, bevor von der Spezifikation abgewichen wird.
+   und "NICHT EMPFOHLEN" bedeuten, dass es gute Gründe in speziellen 
+   Situationen geben kann, dass dieses Verhalten akzeptabel, ja sogar nützlich 
+   sein kann. Natürlich müssen die Auswirkungen voll und ganz verstanden und 
+   sorgfältig abgewägt werden bevor von der Spezifikation abgewichen wird.
 
 DARF
-   oder "KANN", "NICHT NÖTIG" oder das Adjektiv "OPTIONAL" bedeuten, dass
+   sowie "KANN", "NICHT NÖTIG" und das Adjektiv "OPTIONAL" bedeuten, dass 
    dieses Verhalten wirklich optional ist.
    
    Wichtig bei der Definition einer Interaktion oder Protokolls: Ein Anbieter
    kann entscheiden dieses Verhalten einzuschliessen, weil es das Produkt
    verbessert oder für einen speziellen Markt erforderlich ist. Ein anderer
-   Anbieter kann dieses Verhalten weglassen. Eine Implementation die dieses
-   Verhalten weglässt MUSS bereit sein, mit einer anderen Implementation welche
-   dieses Verhalten einschliesst, zu interagieren. In der selben Art MUSS eine
-   Implementation die dieses Verhalten einschliesst mit einer Implementation die
-   dieses Verhalten weglässt interagieren können.
+   Anbieter kann dieses Verhalten weglassen. Eine Implementation, die dieses
+   Verhalten weglässt, MUSS bereit sein, mit einer anderen Implementation welche
+   dieses Verhalten einschliesst, zu interagieren. In derselben Art MUSS eine
+   Implementation, die dieses Verhalten einschließt, mit einer Implementation, 
+   die dieses Verhalten weglässt, interagieren können.
 
-Anmerkung fürs Deutsche: Alle Schlüsselwörter DÜRFEN dekliniert und konjugiert
-werden. Die Grossschreibung ist ausreichend um die Schlüsselwörter zu erkennen.
+Anmerkung für's Deutsche: Alle Schlüsselwörter DÜRFEN dekliniert und konjugiert
+werden. Die Verwendung der vorgeschlagenen Verben im Konjunktiv ist VERBOTEN.
+Die Großschreibung ist ausreichend, um die Schlüsselwörter zu erkennen.
 "NICHT" kann mit "KEIN" ersetzt werden, wie es im Deutschen üblich ist.
 
 Abgrenzung
@@ -69,29 +71,30 @@ Abgrenzung
 
 1. Leitlinie für die Verwendung
 
-   Die Gebote, die in diesem Memo definiert sind, sollen sparsam und mit Sorgfalt
-   eingesetzt werden. Im speziellen ist es NÖTIG, sie nur dort zu benutzen, wo es für
-   die Interaktion wichtig ist oder um nachteiliges Verhalten auszuschliessen.
+   Die Grundsätze, die in diesem Memo definiert sind, sollen sparsam und mit 
+   Sorgfalt eingesetzt werden. Im Speziellen ist es NÖTIG, sie nur dort zu 
+   benutzen, wo es für die Interaktion wichtig ist oder um nachteiliges 
+   Verhalten auszuschliessen.
    Sie DÜRFEN KEINE Implementationsdetails vorschreiben, welche unabhängig von
    der Interaktion sind.
 
 2. Sicherheitsbedenken
 
-   Diese Begriffe werden oft verwendet um sicherheitsrelevantes Verhalten zu
-   definieren. Ein MUSS oder SOLL wegzulassen oder etwas zu tun, das als
-   DARF NICHT oder SOLL NICHT definiert ist, kann subtile Auswirkungen haben.
-   Autoren sollten sich Zeit nehmen, um über Sicherheitsauswirkungen
-   nachzudenken, da die Anwender des Dokuments unter Umständen nicht über die
-   selbe Erfahrung und Hintergrundwissen verfügen.
+   Diese Begriffe werden oft verwendet, um sicherheitsrelevantes Verhalten zu
+   definieren. Ein "MUSS" oder "SOLL" wegzulassen oder etwas zu tun, das als
+   "DARF NICHT" oder "SOLL NICHT" definiert ist, kann subtile Auswirkungen 
+   haben. Autoren sollten sich Zeit nehmen, um über Sicherheitsauswirkungen
+   nachzudenken, da die Anwender des Dokuments unter Umständen nicht über 
+   dieselbe Erfahrung und Hintergrundwissen verfügen.
 
 Danksagung
 ----------
 
-Ich danke den Autoren des RFCs 2119, welches es mir ermöglicht hat 2119de zu
+Ich danke den Autoren des RFCs 2119, welches es mir ermöglicht hat, 2119de zu
 schreiben.
 
-Die Definitionen basieren auf existierenden RFCs. Zusätzlich sind
-Anmerkungen einer Reihe von weiteren Personen eingeflossen, unter anderem Robert Ullmann,
+Die Definitionen basieren auf existierenden RFCs. Zusätzlich sind Anmerkungen 
+einer Reihe von weiteren Personen eingeflossen, unter anderem Robert Ullmann,
 Thomas Narten, Neal McBurnett and Robert Elz.
 
 Autor des orginal RFCs 2119::


### PR DESCRIPTION
anlass dieses commits war vor allem der falsche gebrauch des morphems 'groß'
mit kurzem vokal. relative häufig waren auch nebensätze nicht klar abgetrennt.

es sollte jetzt durchweg bei 80 zeichen gewrappt sein.

außerdem ist ein explizites verbot des verwendens von konjunktiven für die
verwendung im deutschen hinzugefügt worden. zuweilen werden diese aus
einer merkwürdigen rhetorischen praxis heraus statt des indikativs verwendet.

die bildung des genetivs von RFC sehe ich kritisch. 

durchweg verwendet das dokument den generischen maskulin. dagegen gibt es in der sozio-linguistik nme valide einwände. nme SOLLTE damit ein angemessener umgang gefunden werden.